### PR TITLE
Match site interface

### DIFF
--- a/generators/app/templates/site.js
+++ b/generators/app/templates/site.js
@@ -50,7 +50,7 @@ class <%= upperCaseSite %>Site {
     return category;
   }
 
-  findNameOnPage($) {
+  findNameOnPage($, category) {
     // the various ways we can find the name
     const selectors = [
       '',


### PR DESCRIPTION
Even though these variables might not be used, we should include them to give the user an understanding of what’s available and let them choose if they want to remove those inputs or leave them there.